### PR TITLE
docs: add optional system design practice prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,4 @@ Implementation of large systems.
 In mainly Java\Springboot but we can see other languages\frmeworks like python and JS
 Credit
 several of the high level desgins come from [HelloInterview](https://www.hellointerview.com/) 
+Additional practice prompts: [PracHub](https://prachub.com/categories/system-design) - company-tagged system design prompts for selecting implementation exercises.


### PR DESCRIPTION
## Summary

- Add one optional PracHub prompt source after the existing HelloInterview credit.
- Keep the HelloInterview attribution and every existing resource unchanged.

## Context

The maintainer indicated in #25 that this small addition would be welcome. The new line positions PracHub only as a source of company-tagged prompts for selecting implementation exercises.

## Validation

- One README line added
- `git diff --check` passed
- Destination URL returns HTTP 200

Disclosure: I am the founder of PracHub and am submitting this resource for independent maintainer review.